### PR TITLE
Add French word-of-the-day locale

### DIFF
--- a/locale/fr-fr/WordOfTheDayKeyword.voc
+++ b/locale/fr-fr/WordOfTheDayKeyword.voc
@@ -1,4 +1,6 @@
 dis-moi le mot du jour
 donne-moi le mot du jour
+donne-moi le mot du jour d'aujourd'hui
 mot du jour
 quel est le mot du jour
+quel est le mot du jour aujourd'hui

--- a/locale/fr-fr/WordOfTheDayKeyword.voc
+++ b/locale/fr-fr/WordOfTheDayKeyword.voc
@@ -1,0 +1,4 @@
+dis-moi le mot du jour
+donne-moi le mot du jour
+mot du jour
+quel est le mot du jour

--- a/locale/fr-fr/unknown.wod.dialog
+++ b/locale/fr-fr/unknown.wod.dialog
@@ -1,0 +1,1 @@
+Je ne connais pas encore le mot du jour dans cette langue.

--- a/locale/fr-fr/unknown.wod.dialog
+++ b/locale/fr-fr/unknown.wod.dialog
@@ -1,1 +1,1 @@
-Je ne connais pas encore le mot du jour dans cette langue.
+Je ne peux pas encore donner le mot du jour en français.

--- a/locale/fr-fr/word.of.day.dialog
+++ b/locale/fr-fr/word.of.day.dialog
@@ -1,0 +1,1 @@
+Le mot du jour est {word}

--- a/locale/fr-fr/word.of.day.dialog
+++ b/locale/fr-fr/word.of.day.dialog
@@ -1,1 +1,1 @@
-Le mot du jour est {word}
+Le mot du jour est {word}.

--- a/translations/fr-fr/dialogs.json
+++ b/translations/fr-fr/dialogs.json
@@ -1,0 +1,8 @@
+{
+  "word.of.day.dialog": [
+    "Le mot du jour est {word}"
+  ],
+  "unknown.wod.dialog": [
+    "Je ne connais pas encore le mot du jour dans cette langue."
+  ]
+}

--- a/translations/fr-fr/dialogs.json
+++ b/translations/fr-fr/dialogs.json
@@ -1,8 +1,8 @@
 {
   "word.of.day.dialog": [
-    "Le mot du jour est {word}"
+    "Le mot du jour est {word}."
   ],
   "unknown.wod.dialog": [
-    "Je ne connais pas encore le mot du jour dans cette langue."
+    "Je ne peux pas encore donner le mot du jour en français."
   ]
 }

--- a/translations/fr-fr/vocabs.json
+++ b/translations/fr-fr/vocabs.json
@@ -1,0 +1,8 @@
+{
+  "WordOfTheDayKeyword.voc": [
+    "dis-moi le mot du jour",
+    "donne-moi le mot du jour",
+    "quel est le mot du jour",
+    "mot du jour"
+  ]
+}

--- a/translations/fr-fr/vocabs.json
+++ b/translations/fr-fr/vocabs.json
@@ -2,7 +2,9 @@
   "WordOfTheDayKeyword.voc": [
     "dis-moi le mot du jour",
     "donne-moi le mot du jour",
+    "donne-moi le mot du jour d'aujourd'hui",
     "quel est le mot du jour",
+    "quel est le mot du jour aujourd'hui",
     "mot du jour"
   ]
 }


### PR DESCRIPTION
## Summary
- add `translations/fr-fr/dialogs.json` and `translations/fr-fr/vocabs.json`
- sync the generated `locale/fr-fr` files
- add French utterances and dialogs for the skill

## Notes
- this PR only adds the missing French locale resources
- it does not change the skill logic for fetching a French word source

## Testing
- `git diff --check`
- parsed the new `translations/fr-fr/*.json`
- verified `fr-fr` file coverage now matches `en-us`
