### PR TITLE
Fix Dictionary.com word of the day parser

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -12,4 +12,4 @@ jobs:
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       install_extras: 'test'
-      test_path: 'test'
+      test_path: 'test/test_dictionary_wod.py'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,6 @@ jobs:
     with:
       python_version: '3.11'
       coverage_source: 'ovos_skill_word_of_the_day'
-      test_path: 'test/'
+      test_path: 'test/test_dictionary_wod.py'
       install_extras: ''
       min_coverage: 0

--- a/.github/workflows/ovoscope.yml
+++ b/.github/workflows/ovoscope.yml
@@ -13,3 +13,4 @@ jobs:
       python_version: '3.11'
       install_extras: 'test'
       test_path: 'test/end2end/'
+      require_adapt: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/__init__.py
+++ b/__init__.py
@@ -7,6 +7,7 @@ from bs4 import BeautifulSoup
 from ovos_workshop.decorators import intent_handler
 from ovos_workshop.intents import IntentBuilder
 from ovos_workshop.skills.auto_translatable import OVOSSkill
+from ovos_utils.log import LOG
 from ovos_utils.time import now_local
 
 
@@ -17,6 +18,7 @@ REQUEST_HEADERS = {
 }
 FR_WIKTIONARY_API = "https://fr.wiktionary.org/w/api.php"
 FR_WIKTIONARY_PAGE = "Wiktionnaire:Page d’accueil"
+DICTIONARY_WOD_URL = "https://www.dictionary.com/e/word-of-the-day"
 
 
 def _http_get(url, **kwargs):
@@ -40,6 +42,47 @@ def _normalize_definition_text(text: str) -> str:
     return text.strip()
 
 
+def _dictionary_definition_text(node) -> str:
+    if "otd-item-headword__pos-blocks" in (node.get("class") or []):
+        lines = [
+            line.strip()
+            for line in node.get_text("\n", strip=True).splitlines()
+            if line.strip()
+        ]
+        if lines:
+            return lines[-1]
+    return node.get_text(" ", strip=True)
+
+
+def _extract_dictionary_wod(html: str, url: str = DICTIONARY_WOD_URL):
+    soup = BeautifulSoup(html, "html.parser")
+
+    entry = soup.find(class_="wotd-entry-wrapper")
+    word_node = None
+    definition_node = None
+    if entry is not None:
+        word_node = entry.find(class_="wotd-entry-headword")
+        definition_node = entry.find(class_="wotd-entry-definition")
+
+    word_node = word_node or soup.find("div", {
+        "class": "otd-item-headword__word"
+    }) or soup.find(class_="wotd-entry-headword")
+    definition_node = definition_node or soup.find("div", {
+        "class": "otd-item-headword__pos-blocks"
+    }) or soup.find(class_="wotd-entry-definition")
+
+    if word_node is None or definition_node is None:
+        raise RuntimeError(f"Failed to parse word of the day from '{url}'")
+
+    wod = _normalize_definition_text(word_node.get_text(" ", strip=True))
+    definition = _normalize_definition_text(
+        _dictionary_definition_text(definition_node)
+    )
+    if not wod or not definition:
+        raise RuntimeError(f"Failed to parse word of the day from '{url}'")
+    return wod, definition
+
+
 def get_wod_gl(date: Optional[Union[datetime.datetime, datetime.date]] = None):
     url = 'https://portaldaspalabras.gal/lexico/palabra-do-dia'
     now = date or now_local()
@@ -58,7 +101,7 @@ def get_wod_gl(date: Optional[Union[datetime.datetime, datetime.date]] = None):
                 response = _http_post(u, data=data)
                 if response.status_code == 200:
                     return response
-            except:
+            except Exception:
                 continue
         raise RuntimeError(f"Failed to retrieve data from '{url}'")
 
@@ -80,17 +123,9 @@ def get_wod_gl(date: Optional[Union[datetime.datetime, datetime.date]] = None):
 
 
 def get_wod():
-    html = _http_get("https://www.dictionary.com/e/word-of-the-day").text
-
-    soup = BeautifulSoup(html, "html.parser")
-
-    h = soup.find("div", {"class": "otd-item-headword__word"})
-    wod = h.text.strip()
-
-    h = soup.find("div", {"class": "otd-item-headword__pos-blocks"})
-    definition = h.text.strip().split("\n")[-1]
-
-    return wod, definition
+    response = _http_get(DICTIONARY_WOD_URL)
+    response.raise_for_status()
+    return _extract_dictionary_wod(response.text)
 
 
 def get_wod_pt(pt_br=False):
@@ -166,20 +201,26 @@ class WordOfTheDaySkill(OVOSSkill):
 
     @intent_handler(IntentBuilder("WordOfTheDayIntent").require("WordOfTheDayKeyword"))
     def handle_word_of_the_day_intent(self, message):
-        l = self.lang.lower()
-        if l.lower() == "pt-br":
-            wod, definition = get_wod_pt(pt_br=True)
-        elif l.lower().split("-")[0] == "pt":
-            wod, definition = get_wod_pt()
-        elif l.lower().split("-")[0] == "en":
-            wod, definition = get_wod()
-        elif l.lower().split("-")[0] == "fr":
-            wod, definition = get_wod_fr()
-        elif l.lower().split("-")[0] == "ca":
-            wod, definition = get_wod_ca()
-        elif l.lower().split("-")[0] == "gl":
-            wod, definition = get_wod_gl()
-        else:
+        lang = self.lang.lower()
+        primary_lang = lang.split("-")[0]
+        try:
+            if lang == "pt-br":
+                wod, definition = get_wod_pt(pt_br=True)
+            elif primary_lang == "pt":
+                wod, definition = get_wod_pt()
+            elif primary_lang == "en":
+                wod, definition = get_wod()
+            elif primary_lang == "fr":
+                wod, definition = get_wod_fr()
+            elif primary_lang == "ca":
+                wod, definition = get_wod_ca()
+            elif primary_lang == "gl":
+                wod, definition = get_wod_gl()
+            else:
+                self.speak_dialog("unknown.wod")
+                return
+        except Exception:
+            LOG.exception("Failed to retrieve word of the day")
             self.speak_dialog("unknown.wod")
             return
 

--- a/test/end2end/__init__.py
+++ b/test/end2end/__init__.py
@@ -1,0 +1,1 @@
+"""End-to-end tests for ovos-skill-word-of-the-day."""

--- a/test/end2end/test_word_of_the_day_intent.py
+++ b/test/end2end/test_word_of_the_day_intent.py
@@ -1,0 +1,105 @@
+import sys
+from unittest import TestCase
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+from ovos_utils.log import LOG
+from ovoscope import End2EndTest, get_minicroft
+
+
+SKILL_ID = "ovos-skill-word-of-the-day.openvoiceos"
+INTENT = f"{SKILL_ID}:WordOfTheDayIntent"
+SECONDARY_LANGS = ["ca-ES", "fr-FR", "gl-ES", "pt-PT"]
+SOURCE_FUNCTIONS = ("get_wod", "get_wod_ca", "get_wod_fr",
+                    "get_wod_gl", "get_wod_pt")
+IGNORE_MESSAGES = [
+    "speak",
+    "ovos.common_play.stop.response",
+    "common_query.openvoiceos.stop.response",
+    "persona.openvoiceos.stop.response",
+    "stop.openvoiceos.stop.response",
+]
+
+
+class TestWordOfTheDayIntentRouting(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        LOG.set_level("DEBUG")
+        cls.calls = []
+        cls.minicroft = get_minicroft(
+            [SKILL_ID],
+            secondary_langs=SECONDARY_LANGS,
+        )
+        skill = cls.minicroft.plugin_skills[SKILL_ID].instance
+        cls.skill_module = sys.modules[skill.__class__.__module__]
+        cls.originals = {
+            name: getattr(cls.skill_module, name)
+            for name in SOURCE_FUNCTIONS
+        }
+        for source_name in SOURCE_FUNCTIONS:
+            setattr(cls.skill_module, source_name, cls._source(source_name))
+
+    @classmethod
+    def tearDownClass(cls):
+        for name, source in getattr(cls, "originals", {}).items():
+            setattr(cls.skill_module, name, source)
+        if getattr(cls, "minicroft", None):
+            cls.minicroft.stop()
+        LOG.set_level("CRITICAL")
+
+    @classmethod
+    def _source(cls, source_name):
+        def source(*args, **kwargs):
+            cls.calls.append((source_name, args, kwargs))
+            return f"{source_name}-word", f"{source_name} definition"
+        return source
+
+    def setUp(self):
+        self.calls.clear()
+
+    def _assert_routes_to_source(self, utterance, lang, source_name):
+        session = Session(f"wod-{lang}-{abs(hash(utterance))}")
+        session.lang = lang
+        session.pipeline = ["ovos-adapt-pipeline-plugin-high"]
+        message = Message(
+            "recognizer_loop:utterance",
+            {"utterances": [utterance], "lang": lang},
+            {"session": session.serialize()},
+        )
+
+        test = End2EndTest(
+            minicroft=self.minicroft,
+            skill_ids=[SKILL_ID],
+            eof_msgs=["ovos.utterance.handled"],
+            flip_points=["recognizer_loop:utterance"],
+            ignore_messages=IGNORE_MESSAGES,
+            source_message=message,
+            activation_points=[INTENT],
+            expected_messages=[
+                message,
+                Message(f"{SKILL_ID}.activate", {}, {"skill_id": SKILL_ID}),
+                Message(INTENT, {}, {"skill_id": SKILL_ID}),
+                Message("mycroft.skill.handler.start", {},
+                        {"skill_id": SKILL_ID}),
+                Message("mycroft.skill.handler.complete", {},
+                        {"skill_id": SKILL_ID}),
+                Message("ovos.utterance.handled", {}, {"skill_id": SKILL_ID}),
+            ],
+        )
+        test.execute(timeout=15)
+        self.assertEqual(self.calls, [(source_name, (), {})])
+
+    def test_english_routes_to_dictionary_source(self):
+        self._assert_routes_to_source("word of the day", "en-US", "get_wod")
+
+    def test_french_routes_to_wiktionary_source(self):
+        self._assert_routes_to_source("mot du jour", "fr-FR", "get_wod_fr")
+
+    def test_portuguese_routes_to_priberam_source(self):
+        self._assert_routes_to_source("palavra do dia", "pt-PT", "get_wod_pt")
+
+    def test_galician_routes_to_portal_das_palabras_source(self):
+        self._assert_routes_to_source("palabra do día", "gl-ES", "get_wod_gl")
+
+    def test_catalan_routes_to_rodamots_source(self):
+        self._assert_routes_to_source("mot del dia", "ca-ES", "get_wod_ca")

--- a/test/test_dictionary_wod.py
+++ b/test/test_dictionary_wod.py
@@ -1,0 +1,102 @@
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "__init__.py"
+SPEC = importlib.util.spec_from_file_location("word_of_the_day_skill", MODULE_PATH)
+skill = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(skill)
+
+
+class DummyGui:
+    def __init__(self):
+        self.text = []
+
+    def show_text(self, definition, word):
+        self.text.append((definition, word))
+
+
+class DummyLog:
+    def __init__(self):
+        self.exceptions = []
+
+    def exception(self, message):
+        self.exceptions.append(message)
+
+
+def make_skill_instance(lang="en-US"):
+    instance = SimpleNamespace(
+        lang=lang,
+        gui=DummyGui(),
+        dialogs=[],
+        speech=[]
+    )
+    instance.speak_dialog = (
+        lambda dialog, data=None: instance.dialogs.append((dialog, data))
+    )
+    instance.speak = lambda text: instance.speech.append(text)
+    return instance
+
+
+def test_extract_dictionary_wod_from_current_markup():
+    html = """
+    <div class="wotd-entry-wrapper">
+        <div class="wotd-entry-date">May 12, 2026</div>
+        <a class="wotd-entry-headword">rigmarole</a>
+        <p class="wotd-entry-definition">
+            an elaborate or complicated procedure
+        </p>
+    </div>
+    <div class="wotd-entry-wrapper">
+        <a class="wotd-entry-headword">scupper</a>
+        <p class="wotd-entry-definition">
+            to prevent from happening or succeeding
+        </p>
+    </div>
+    """
+
+    assert skill._extract_dictionary_wod(html) == (
+        "rigmarole",
+        "an elaborate or complicated procedure"
+    )
+
+
+def test_extract_dictionary_wod_from_legacy_markup():
+    html = """
+    <div class="otd-item-headword__word">halcyon</div>
+    <div class="otd-item-headword__pos-blocks">
+        <span>adjective</span>
+        <p>happy; blissful; carefree</p>
+    </div>
+    """
+
+    assert skill._extract_dictionary_wod(html) == (
+        "halcyon",
+        "happy; blissful; carefree"
+    )
+
+
+def test_extract_dictionary_wod_raises_clear_error_for_unknown_markup():
+    with pytest.raises(RuntimeError, match="Failed to parse word of the day"):
+        skill._extract_dictionary_wod("<html></html>")
+
+
+def test_handler_speaks_unknown_when_source_fails(monkeypatch):
+    log = DummyLog()
+
+    def fail():
+        raise RuntimeError("source changed")
+
+    monkeypatch.setattr(skill, "LOG", log)
+    monkeypatch.setattr(skill, "get_wod", fail)
+
+    instance = make_skill_instance()
+    skill.WordOfTheDaySkill.handle_word_of_the_day_intent(instance, None)
+
+    assert instance.dialogs == [("unknown.wod", None)]
+    assert instance.gui.text == []
+    assert instance.speech == []
+    assert log.exceptions == ["Failed to retrieve word of the day"]


### PR DESCRIPTION
## Summary
- Update the Dictionary.com parser for the current `wotd-entry-*` markup while keeping the older selectors as a fallback.
- Return `unknown.wod` when a word-of-the-day source fails instead of letting the handler raise.
- Include `requirements.txt` in source distributions so installs keep the runtime dependencies.
- Add parser coverage and ovoscope intent-routing checks for the supported WOD source languages.
- Keep unit tests in the build/coverage jobs and leave the bus-level checks to ovoscope with Adapt installed.

## Testing
- `ruff check . --exclude _gh_automations`
- `python -m pytest test/test_dictionary_wod.py`
- `python -m pytest test/end2end/`
- `python -m pytest test/test_dictionary_wod.py test/end2end/`
- `python -m py_compile __init__.py test/test_dictionary_wod.py test/end2end/test_word_of_the_day_intent.py`

Closes #27
